### PR TITLE
Nav Readability and Accessibility Fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gem 'github-pages', group: :jekyll_plugins
 #gem 'sass'
 #gem 'octopress', '~> 3.0.0.rc.12'
 gem 'jekyll-sitemap'
+
+gem "webrick", "~> 1.7"

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ gem 'github-pages', group: :jekyll_plugins
 #gem 'octopress', '~> 3.0.0.rc.12'
 gem 'jekyll-sitemap'
 
-gem "webrick", "~> 1.7"
+#gem "webrick", "~> 1.7"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,10 @@
 <!-- Page Header -->
 <header
   class="intro-header"
-  style="background-image: url('{{ site.url }}/{% if page.header-img %}{{ page.header-img }}{% else %}{{ site.header-img }}{% endif %}')">
+  style="
+    background-image: linear-gradient( rgba(83,83,83,.5), rgba(255,255,255,0)),
+    url('{{ site.url }}/{% if page.header-img %}{{ page.header-img }}{% else %}{{ site.header-img }}{% endif %}');
+  ">
   <div class="container">
     <div class="row">
       <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">


### PR DESCRIPTION
This fixes #1 
--
I didn't notice when testing the filters in browser
```css
.intro-header {
  filter : contrast(70%);
}
```
would also affect the nested h1 tag and subheading(s).
To hack around this a gradient, starting with a semi opaque light gray that transitions to transparent white, was used.
The goal was to create contrast around the nav items while preserving text and photos.
Changes are most noticeable on the Research page on a Retina display. 